### PR TITLE
Upgrade Shiki to the latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# IntelliJ
+.idea

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "prepublish": "yarn lint && yarn test"
     },
     "files": [
-        "dist/**/*"
+        "dist/**/*",
+        "!dist/**/__tests__/**/*"
     ],
     "author": "Morsby",
     "repository": {
@@ -35,7 +36,6 @@
         "eslint": "^7.0.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.3",
-        "estree-walker": "^2.0.1",
         "husky": "^4.2.5",
         "jest": "^25.3.0",
         "magic-string": "^0.25.7",
@@ -48,6 +48,7 @@
         "typescript": "^3.8.3"
     },
     "dependencies": {
+        "estree-walker": "^2.0.1",
         "shiki": "^0.1.7"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
         "prettier": "^2.0.5",
         "shiki-languages": "^0.1.6",
         "shiki-themes": "^0.1.7",
-        "svelte": "^3.22.2",
+        "svelte": "^3.59.1",
         "ts-jest": "^25.3.1",
         "typescript": "^3.8.3"
     },
     "dependencies": {
         "estree-walker": "^2.0.1",
-        "shiki": "^0.1.7"
+        "shiki": "^0.14.2"
     },
     "peerDependencies": {
         "svelte": "^3.0.0"

--- a/src/__tests__/highlighter.ts
+++ b/src/__tests__/highlighter.ts
@@ -7,10 +7,10 @@ console.log(foo)
 `.trim();
 
     const expected = `
-<pre class="shiki" style="background-color: #2e3440"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #88C0D0">bar</span><span style="color: #D8DEE9FF">()</span><span style="color: #81A1C1">;</span>
-<span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span></code></pre>
+<pre class="shiki" style="background-color: #2e3440ff"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #88C0D0">bar</span><span style="color: #D8DEE9FF">()</span><span style="color: #81A1C1">;</span>
+<span style="color: #D8DEE9">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span></code></pre>
 `.trim();
     const highlighter = await initHighlighter();
-    const tokens = highlighter.codeToThemedTokens(codeToHighlight, "js");
+    const tokens = highlighter.instance.codeToThemedTokens(codeToHighlight, "js");
     expect(renderToHtml(tokens, { bg: highlighter.theme.bg })).toBe(expected);
 });

--- a/src/__tests__/preprocessor.ts
+++ b/src/__tests__/preprocessor.ts
@@ -20,8 +20,8 @@ describe("end-to-end", () => {
         });
 
         expect(preprocessed.code).toBe(
-            `<pre class="shiki" style="background-color: #2e3440"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #ECEFF4">"</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">"</span><span style="color: #81A1C1">;</span>
-<span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></code></pre>\n`,
+            `<pre class="shiki" style="background-color: #2e3440ff"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #ECEFF4">"</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">"</span><span style="color: #81A1C1">;</span>
+<span style="color: #D8DEE9">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></code></pre>\n`,
         );
     });
 
@@ -31,7 +31,7 @@ describe("end-to-end", () => {
         });
 
         expect(preprocessed.code).toBe(
-            `<code class="shiki" style="background-color: #2e3440"><span style="color: #D8DEE9">confirm</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">\'</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">\'</span><span style="color: #D8DEE9FF">)</span></code>\n`,
+            `<code class="shiki" style="background-color: #2e3440ff"><span style="color: #D8DEE9">confirm</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">\'</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">\'</span><span style="color: #D8DEE9FF">)</span></code>\n`,
         );
     });
 
@@ -41,7 +41,7 @@ describe("end-to-end", () => {
         });
 
         expect(preprocessed.code).toBe(
-            '<script>\n    let name = "Johnny";\n</script>\n\n<style>\n    h1 {\n        color: red;\n    }\n</style>\n\n<h1>Well done, {name}!</h1>\n<img alt="Happy kid, yo" src="successkid.jpg" />\n\n<p>\n    <strong>Try editing this file (src/routes/index.svelte) to test live reloading.</strong>\n</p>\n<pre class="shiki" style="background-color: #2e3440"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #88C0D0">bar</span><span style="color: #D8DEE9FF">()</span></code></pre>\n',
+            '<script>\n    let name = "Johnny";\n</script>\n\n<style>\n    h1 {\n        color: red;\n    }\n</style>\n\n<h1>Well done, {name}!</h1>\n<img alt="Happy kid, yo" src="successkid.jpg" />\n\n<p>\n    <strong>Try editing this file (src/routes/index.svelte) to test live reloading.</strong>\n</p>\n<pre class="shiki" style="background-color: #2e3440ff"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #88C0D0">bar</span><span style="color: #D8DEE9FF">()</span></code></pre>\n',
         );
     });
 });
@@ -53,8 +53,8 @@ describe("mdsvex / markdown", () => {
         });
 
         expect(preprocessed.code).toBe(
-            `<pre class="shiki" style="background-color: #2e3440"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #ECEFF4">"</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">"</span><span style="color: #81A1C1">;</span>
-<span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></code></pre>\n`,
+            `<pre class="shiki" style="background-color: #2e3440ff"><code><span style="color: #81A1C1">const</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF">&#8199;</span><span style="color: #ECEFF4">"</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">"</span><span style="color: #81A1C1">;</span>
+<span style="color: #D8DEE9">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">foo</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></code></pre>\n`,
         );
     });
 
@@ -64,7 +64,7 @@ describe("mdsvex / markdown", () => {
         });
 
         expect(preprocessed.code).toBe(
-            `<p>This is inline javascript code: <code class="shiki" style="background-color: #2e3440"><span style="color: #D8DEE9">confirm</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">\'</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">\'</span><span style="color: #D8DEE9FF">)</span></code>.</p>\n`,
+            `<p>This is inline javascript code: <code class="shiki" style="background-color: #2e3440ff"><span style="color: #D8DEE9">confirm</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">\'</span><span style="color: #A3BE8C">svelte-shiki</span><span style="color: #ECEFF4">\'</span><span style="color: #D8DEE9FF">)</span></code>.</p>\n`,
         );
     });
 });

--- a/src/highlighter.ts
+++ b/src/highlighter.ts
@@ -76,6 +76,7 @@ export const initHighlighter = async (options?: HighlighterOptions): Promise<Sve
     };
 
     return {
+        instance: highlighter,
         highlight,
         theme,
     };

--- a/src/highlighter.ts
+++ b/src/highlighter.ts
@@ -1,6 +1,5 @@
-import { getHighlighter, IThemedToken, getTheme } from "shiki";
-import { HighlighterOptions } from "shiki/dist/highlighter";
-import { IShikiTheme } from "shiki-themes";
+import { getHighlighter, IThemedToken, HighlighterOptions } from "shiki";
+import { TLang } from "shiki-languages";
 import { SvelteHighlighter, RendererOptions } from "./types";
 import { escapeHtml } from "./utils";
 
@@ -47,28 +46,20 @@ const isPlaintext = (lang: string): boolean => {
     return ["plaintext", "txt", "text"].indexOf(lang) !== -1;
 };
 
-export const initHighlighter = async (options?: HighlighterOptions): Promise<SvelteHighlighter> => {
-    const defaultOptions: HighlighterOptions = {
-        theme: "nord",
-    };
+const defaultOptions: HighlighterOptions = {
+    theme: "nord",
+};
 
+export const initHighlighter = async (options?: HighlighterOptions): Promise<SvelteHighlighter> => {
     options = { ...defaultOptions, ...options };
 
-    // get theme
-    let theme: IShikiTheme;
-    if (typeof options.theme === "string") {
-        theme = getTheme(options.theme);
-    } else if (options.theme.name) {
-        theme = options.theme;
-    } else {
-        theme = getTheme("nord");
-    }
-
-    const highlighter = (await getHighlighter({
+    const highlighter = await getHighlighter({
         theme: options.theme,
-    })) as SvelteHighlighter;
+    });
 
-    highlighter.highlight = (code, lang, inline = false): string => {
+    const theme = highlighter.getTheme();
+
+    const highlight = (code: string, lang: TLang, inline = false): string => {
         code = code.trim();
         if (isPlaintext(lang)) {
             return renderToHtml([[{ content: code }]], {
@@ -84,6 +75,8 @@ export const initHighlighter = async (options?: HighlighterOptions): Promise<Sve
         });
     };
 
-    highlighter.theme = theme;
-    return highlighter;
+    return {
+        highlight,
+        theme,
+    };
 };

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -5,8 +5,7 @@ import { SvelteNode, SvelteAst } from "./types";
 import { initHighlighter } from "./highlighter";
 import { getProp, replaceContents } from "./utils";
 import { PreprocessorGroup, Processed } from "svelte/types/compiler/preprocess";
-
-import { HighlighterOptions } from "shiki/dist/highlighter";
+import { HighlighterOptions } from "shiki";
 
 const highlightCode = async (content: string, options?: HighlighterOptions): Promise<string> => {
     // if no code elements, return

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,7 @@
 import { Ast } from "svelte/types/compiler/interfaces";
-import { Highlighter } from "shiki/dist/highlighter";
+import { Highlighter, HtmlRendererOptions } from "shiki";
 import { IShikiTheme } from "shiki-themes";
 import { TLang } from "shiki-languages";
-import { HtmlRendererOptions } from "shiki/dist/renderer";
 
 // AST/Nodes
 export interface Value {
@@ -39,7 +38,7 @@ export interface SvelteAst extends Ast {
 // Highlighter
 
 // Extend the Highlighter to include the custom renderer and a theme prop
-export interface SvelteHighlighter extends Highlighter {
+export interface SvelteHighlighter {
     theme: IShikiTheme;
     highlight(code: string, lang: TLang, inline?: boolean): string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface SvelteAst extends Ast {
 
 // Extend the Highlighter to include the custom renderer and a theme prop
 export interface SvelteHighlighter {
+    instance: Highlighter;
     theme: IShikiTheme;
     highlight(code: string, lang: TLang, inline?: boolean): string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "esModuleInterop": true
   },
   "include": ["src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,6 +690,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz#4d790f31236ac20366b23b3916b789e1bde39aed"
+  integrity sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -940,11 +945,6 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -982,7 +982,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.3.0:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1096,11 +1096,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@^2.12.1:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 compare-versions@^3.6.0:
   version "3.6.0"
@@ -1268,11 +1263,6 @@ diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2651,6 +2641,11 @@ json5@2.x, json5@^2.1.0, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2751,13 +2746,6 @@ lolex@^5.0.0:
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
 
 magic-string@^0.25.7:
   version "0.25.7"
@@ -3045,14 +3033,6 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
-
-onigasm@^2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.4.tgz#b0ad97e3d7c3080476a1e5daae4b4579a976cbba"
-  integrity sha512-BJKxCTsK0mrLh+A6AuNzknxaULZRKM5uywA2goluMLLCjfMm/PTUa0M7oSH1Ltb6CT1oKXn2atHR75Y3JQ0SSg==
-  dependencies:
-    lru-cache "^5.1.1"
-    tslint "^5.20.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -3539,7 +3519,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3613,15 +3593,15 @@ shiki-themes@^0.1.7:
     json5 "^2.1.0"
     vscode-textmate "https://github.com/octref/vscode-textmate"
 
-shiki@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.1.7.tgz#138eed000063a80e44eedc800381977c690271e5"
-  integrity sha512-9J0PhAdXv6tt3FZf82oKZkcV8c8NRZYJEOH0eIrrxfcyNzMuB79tJFGFSI3OhhiYFL5namob/Ii0Ri4iDoF15A==
+shiki@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.2.tgz#d51440800b701392b31ce2336036058e338247a1"
+  integrity sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==
   dependencies:
-    onigasm "^2.2.1"
-    shiki-languages "^0.1.6"
-    shiki-themes "^0.1.7"
-    vscode-textmate "https://github.com/octref/vscode-textmate"
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -3874,7 +3854,7 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte@^3.22.2:
+svelte@^3.59.1:
   version "3.59.1"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.59.1.tgz#3de3d56b9165748f32f3131589b8d183cabe7449"
   integrity sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==
@@ -4015,36 +3995,10 @@ ts-jest@^25.3.1:
     semver "6.x"
     yargs-parser "18.x"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
-
-tslint@^5.20.1:
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
-  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^4.0.1"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.29.0"
-
-tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  dependencies:
-    tslib "^1.8.1"
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -4187,6 +4141,16 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
+
 "vscode-textmate@https://github.com/octref/vscode-textmate":
   version "4.0.1"
   resolved "https://github.com/octref/vscode-textmate#e65aabe2227febda7beaad31dd0fca1228c5ddf3"
@@ -4319,11 +4283,6 @@ y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
-
-yallist@^3.0.2:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^1.7.2:
   version "1.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,9 +1462,9 @@ estraverse@^5.1.0:
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
 
 estree-walker@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
-  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3875,9 +3875,9 @@ supports-hyperlinks@^2.0.0:
     supports-color "^7.0.0"
 
 svelte@^3.22.2:
-  version "3.22.2"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.22.2.tgz#06585244191bf7a112af2a0025610f33d77c3715"
-  integrity sha512-DxumO0+vvHA6NSc2jtVty08I8lFI43q8P2zX6JxZL8J1kqK5NVjad6TRM/twhnWXC+QScnwkZ15O6X1aTsEKTA==
+  version "3.59.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.59.1.tgz#3de3d56b9165748f32f3131589b8d183cabe7449"
+  integrity sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
- Fixes missing estree-walker dep
- Bump shiki to 0.14.2
- Bump Svelte to 3.59.1
- Reduce final bundle size (remove sourcemaps and ignore tests)